### PR TITLE
Align package name and streamline boolean assertion conversion

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 let package = Package(
-  name: "XCTestMigrator",
+  name: "SwiftTestingMigrator",
   platforms: [
     .macOS(.v13)
   ],


### PR DESCRIPTION
## Summary
- rename package to SwiftTestingMigrator
- clarify boolean assertion helper comments used for true and false checks
- unify true/false assertion conversion through shared helper

## Testing
- `swift build`
- `swift test`
- `./scripts/lint.sh` *(fails: swiftlint: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896275666b4832cabe4b7ba0d61918a