### PR TITLE
Detect unsupported XCTest expectations and improve docs

### DIFF
--- a/Sources/SwiftTestingMigrator/SwiftTestingMigrator.swift
+++ b/Sources/SwiftTestingMigrator/SwiftTestingMigrator.swift
@@ -6,7 +6,7 @@ import SwiftTestingMigratorKit
 struct SwiftTestingMigrator: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "SwiftTestingMigrator",
-        abstract: "A tool to migrate XCTest tests to Swift Testing framework with TCA support",
+        abstract: "A tool to migrate XCTest tests to the Swift Testing framework",
         discussion: """
       This tool performs conservative migration from XCTest to Swift Testing,
       preserving as much of the original code structure as possible while

--- a/Sources/SwiftTestingMigratorKit/SwiftTestingMigratorKit.swift
+++ b/Sources/SwiftTestingMigratorKit/SwiftTestingMigratorKit.swift
@@ -1,8 +1,7 @@
 /// SwiftTestingMigratorKit - Library for migrating XCTest to Swift Testing
 ///
 /// This library provides functionality to automatically convert XCTest-based
-/// test files to use the Swift Testing framework, with special handling for
-/// TCA (The Composable Architecture) patterns.
+/// test files to use the Swift Testing framework.
 
 // Re-export public types
 @_exported import struct Foundation.URL

--- a/Tests/SwiftTestingMigratorKitTests/ErrorHandlingTests.swift
+++ b/Tests/SwiftTestingMigratorKitTests/ErrorHandlingTests.swift
@@ -180,4 +180,31 @@ struct ErrorHandlingTests {
       """
     }
   }
+
+  @Test
+  func expectationPatternsThrowError() {
+    let input = """
+      import XCTest
+
+      final class ExpectationTests: XCTestCase {
+        func test_waits() {
+          let exp = expectation(description: "async work")
+          waitForExpectations(timeout: 1.0)
+        }
+      }
+      """
+
+    let migrator = TestMigrator()
+
+    do {
+      _ = try migrator.migrate(source: input)
+      Issue.record("Expected migration to fail")
+    } catch {
+      assertInlineSnapshot(of: error.localizedDescription, as: .lines) {
+        """
+        Unsupported pattern that cannot be migrated: XCTest expectations (expectation/waitForExpectations) are not supported
+        """
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- fail migration when XCTest expectations are detected
- document lack of expectation support and refresh README
- remove references to TCA-specific support
- add regression test for expectation error handling

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68962bedfd40832c92d2a0a8aef78cca