### PR TITLE
Sort imports during XCTest to Testing migration

### DIFF
--- a/Sources/SwiftTestingMigratorKit/ImportSorter.swift
+++ b/Sources/SwiftTestingMigratorKit/ImportSorter.swift
@@ -1,0 +1,63 @@
+import SwiftSyntax
+
+extension SourceFileSyntax {
+    /// Returns a copy of the source file with import statements sorted alphabetically.
+    func sortedImports() -> SourceFileSyntax {
+        var result: [CodeBlockItemSyntax] = []
+        var buffer: [CodeBlockItemSyntax] = []
+
+        func flushBuffer() {
+            guard !buffer.isEmpty else { return }
+
+            let groupLeadingTrivia = buffer.first!.leadingTrivia
+            var importItems: [(CodeBlockItemSyntax, ImportDeclSyntax)] = buffer.map { item in
+                let decl = item.item.as(ImportDeclSyntax.self)!
+                return (item, decl)
+            }
+
+            importItems.sort { lhs, rhs in
+                let name1 = lhs.1.path.description.trimmingCharacters(in: .whitespacesAndNewlines)
+                let name2 = rhs.1.path.description.trimmingCharacters(in: .whitespacesAndNewlines)
+                return name1.localizedCompare(name2) == .orderedAscending
+            }
+
+            for (index, pair) in importItems.enumerated() {
+                var newDecl = pair.1
+                let leading = index == 0 ? groupLeadingTrivia : Trivia.newlines(1)
+                newDecl = newDecl
+                    .with(\.leadingTrivia, leading)
+                    .with(\.trailingTrivia, pair.1.trailingTrivia)
+                let newItem = pair.0.with(\.item, .decl(DeclSyntax(newDecl)))
+                result.append(newItem)
+            }
+
+            buffer.removeAll()
+        }
+
+        for item in statements {
+            if item.item.as(ImportDeclSyntax.self) != nil {
+                if buffer.isEmpty {
+                    buffer.append(item)
+                } else {
+                    let hasBlankLine = item.leadingTrivia.contains { piece in
+                        if case .newlines(let n) = piece, n >= 2 { return true }
+                        return false
+                    }
+                    if hasBlankLine {
+                        flushBuffer()
+                        buffer.append(item)
+                    } else {
+                        buffer.append(item)
+                    }
+                }
+            } else {
+                flushBuffer()
+                result.append(item)
+            }
+        }
+
+        flushBuffer()
+
+        return with(\.statements, CodeBlockItemListSyntax(result))
+    }
+}

--- a/Sources/SwiftTestingMigratorKit/XCTestToSwiftTestingRewriter.swift
+++ b/Sources/SwiftTestingMigratorKit/XCTestToSwiftTestingRewriter.swift
@@ -14,6 +14,11 @@ final class XCTestToSwiftTestingRewriter: SyntaxRewriter {
     private var testMethodCount = 0
     private var currentTestMethodIndex = 0
 
+    override func visit(_ node: SourceFileSyntax) -> SourceFileSyntax {
+        let processed = super.visit(node)
+        return processed.sortedImports()
+    }
+
     override func visit(_ node: ImportDeclSyntax) -> DeclSyntax {
         // Replace "import XCTest" with "import Testing"
         let importPath = node.path.description.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Tests/SwiftTestingMigratorKitTests/BasicMigrationTests.swift
+++ b/Tests/SwiftTestingMigratorKitTests/BasicMigrationTests.swift
@@ -91,7 +91,7 @@ struct BasicMigrationTests {
     }
 
     @Test
-    func multipleImportsPreserved() throws {
+    func importsAreSorted() throws {
         let input = """
       import Foundation
       import XCTest
@@ -109,9 +109,9 @@ struct BasicMigrationTests {
 
         assertInlineSnapshot(of: result, as: .lines) {
             """
+      import Combine
       import Foundation
       import Testing
-      import Combine
 
       struct MultiImportTests {
         @Test
@@ -124,7 +124,7 @@ struct BasicMigrationTests {
     }
 
     @Test
-    func testableImportsPreserved() throws {
+    func testableImportsSortedWithoutBlankLine() throws {
         let input = """
       import XCTest
       @testable import MyModule
@@ -141,8 +141,45 @@ struct BasicMigrationTests {
 
         assertInlineSnapshot(of: result, as: .lines) {
             """
-      import Testing
       @testable import MyModule
+      import Testing
+
+      struct TestableImportTests {
+        @Test
+        func feature() {
+          #expect(true == true)
+        }
+      }
+      """
+        }
+    }
+
+    @Test
+    func testableImportsMaintainSeparationWithBlankLine() throws {
+        let input = """
+      import Foundation
+      import XCTest
+
+      @testable import ZModule
+      @testable import AModule
+
+      final class TestableImportTests: XCTestCase {
+        func testFeature() {
+          XCTAssertTrue(true)
+        }
+      }
+      """
+
+        let migrator = TestMigrator()
+        let result = try migrator.migrate(source: input)
+
+        assertInlineSnapshot(of: result, as: .lines) {
+            """
+      import Foundation
+      import Testing
+
+      @testable import AModule
+      @testable import ZModule
 
       struct TestableImportTests {
         @Test

--- a/Tests/SwiftTestingMigratorKitTests/ClassStructConversionTests.swift
+++ b/Tests/SwiftTestingMigratorKitTests/ClassStructConversionTests.swift
@@ -57,8 +57,8 @@ struct ClassStructConversionTests {
 
         assertInlineSnapshot(of: result, as: .lines) {
             """
-      import Testing
       import Combine
+      import Testing
 
       final class NetworkTests {
         private var subscriptions = Set<AnyCancellable>()

--- a/Tests/SwiftTestingMigratorKitTests/RealWorldExampleTests.swift
+++ b/Tests/SwiftTestingMigratorKitTests/RealWorldExampleTests.swift
@@ -40,8 +40,8 @@ struct RealWorldExampleTests {
 
         assertInlineSnapshot(of: result, as: .lines) {
             """
-      import DataProcessorKit
       @testable import CoreModel
+      import DataProcessorKit
       import Testing
 
       struct DataConverterTests {
@@ -110,8 +110,8 @@ struct RealWorldExampleTests {
         assertInlineSnapshot(of: result, as: .lines) {
             """
       import ComposableArchitecture
-      import Testing
       @testable import MyFeature
+      import Testing
 
       struct FeatureTests {
         @Test
@@ -176,8 +176,8 @@ struct RealWorldExampleTests {
         assertInlineSnapshot(of: result, as: .lines) {
             """
       import ComposableArchitecture
-      import Testing
       @testable import NetworkFeature
+      import Testing
 
       struct NetworkFeatureTests {
         @Test
@@ -248,12 +248,12 @@ struct RealWorldExampleTests {
 
         assertInlineSnapshot(of: result, as: .lines) {
             """
-      import Foundation
+      @testable import AuthService
       import Combine
       import ComposableArchitecture
+      import Foundation
       import Testing
       @testable import UserManagement
-      @testable import AuthService
 
       final class UserManagementTests {
         private var cancellables: Set<AnyCancellable> = []
@@ -324,10 +324,10 @@ struct RealWorldExampleTests {
 
         assertInlineSnapshot(of: result, as: .lines) {
             """
-      import SwiftUI
-      import SnapshotTesting
-      import Testing
       @testable import MyApp
+      import SnapshotTesting
+      import SwiftUI
+      import Testing
 
       struct PreviewSnapshotTests {
         @Test

--- a/Tests/SwiftTestingMigratorKitTests/SetupTeardownTests.swift
+++ b/Tests/SwiftTestingMigratorKitTests/SetupTeardownTests.swift
@@ -70,8 +70,8 @@ struct SetupTeardownTests {
 
         assertInlineSnapshot(of: result, as: .lines) {
             """
-      import Testing
       import Combine
+      import Testing
 
       final class TeardownTests {
         private var subscriptions = Set<AnyCancellable>()


### PR DESCRIPTION
## Summary
- sort import declarations after replacing XCTest with Testing
- handle testable imports as separate groups when separated by blank lines
- test import sorting with and without @testable separation
- extract import sorting into helper file

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689a59865be8832ca14750185052d896