### PR TITLE
Preserve MainActor annotation during test migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ code stays familiar and easy to review.
 - **Comprehensive assertion mapping** – covers the most common XCTest assertions
 - **Early failure for unsupported expectations** – files using `expectation` or
   `waitForExpectations` produce a clear error message rather than an incorrect migration
+- **Optional MainActor removal** – strip `@MainActor` annotations when not needed
 
 ## Installation
 
@@ -42,6 +43,9 @@ SwiftTestingMigrator --file MyTests.swift --backup
 
 # Verbose output
 SwiftTestingMigrator --file MyTests.swift --verbose
+
+# Remove @MainActor annotations
+SwiftTestingMigrator --file MyTests.swift --remove-main-actor
 ```
 
 ## Examples

--- a/Sources/SwiftTestingMigrator/SwiftTestingMigrator.swift
+++ b/Sources/SwiftTestingMigrator/SwiftTestingMigrator.swift
@@ -54,8 +54,14 @@ struct SwiftTestingMigrator: AsyncParsableCommand {
     )
     var verbose = false
 
+    @Flag(
+        name: .long,
+        help: "Remove @MainActor annotations from test methods"
+    )
+    var removeMainActor = false
+
     func run() async throws {
-        let migrator = TestMigrator()
+        let migrator = TestMigrator(removeMainActor: removeMainActor)
 
         if let folder {
             try processFolder(at: folder, using: migrator)

--- a/Sources/SwiftTestingMigratorKit/TestMigrator.swift
+++ b/Sources/SwiftTestingMigratorKit/TestMigrator.swift
@@ -7,7 +7,11 @@ import SwiftBasicFormat
 /// Main interface for migrating XCTest files to Swift Testing
 public final class TestMigrator: Sendable {
 
-    public init() {}
+    private let removeMainActor: Bool
+
+    public init(removeMainActor: Bool = false) {
+        self.removeMainActor = removeMainActor
+    }
 
     /// Migrate Swift test source code from XCTest to Swift Testing
     /// - Parameter source: The original Swift source code
@@ -31,7 +35,7 @@ public final class TestMigrator: Sendable {
         }
 
         // Apply migration transformations
-        let migrationRewriter = XCTestToSwiftTestingRewriter()
+        let migrationRewriter = XCTestToSwiftTestingRewriter(removeMainActor: removeMainActor)
         let migratedSyntax = migrationRewriter.rewrite(sourceFile)
 
         // Normalize indentation using SwiftBasicFormat

--- a/Tests/SwiftTestingMigratorKitTests/BasicMigrationTests.swift
+++ b/Tests/SwiftTestingMigratorKitTests/BasicMigrationTests.swift
@@ -153,4 +153,126 @@ struct BasicMigrationTests {
       """
         }
     }
+
+    @Test
+    func mainActorAnnotationPreserved() throws {
+        let input = """
+      import XCTest
+
+      final class MainActorTests: XCTestCase {
+        @MainActor func testOnMainActor() {
+          XCTAssertTrue(true)
+        }
+      }
+      """
+
+        let migrator = TestMigrator()
+        let result = try migrator.migrate(source: input)
+
+        assertInlineSnapshot(of: result, as: .lines) {
+            """
+      import Testing
+
+      struct MainActorTests {
+        @MainActor
+        @Test
+        func onMainActor() {
+          #expect(true == true)
+        }
+      }
+      """
+        }
+    }
+
+    @Test
+    func mainActorRemovalOption() throws {
+        let input = """
+      import XCTest
+
+      final class MainActorTests: XCTestCase {
+        @MainActor func testOnMainActor() {
+          XCTAssertTrue(true)
+        }
+      }
+      """
+
+        let migrator = TestMigrator(removeMainActor: true)
+        let result = try migrator.migrate(source: input)
+
+        assertInlineSnapshot(of: result, as: .lines) {
+            """
+      import Testing
+
+      struct MainActorTests {
+        @Test
+        func onMainActor() {
+          #expect(true == true)
+        }
+      }
+      """
+        }
+    }
+
+    @Test
+    func mainActorPreservedWithOtherAttributes() throws {
+        let input = """
+      import XCTest
+
+      final class MainActorAvailabilityTests: XCTestCase {
+        @available(*, deprecated)
+        @MainActor func testOnMainActor() {
+          XCTAssertTrue(true)
+        }
+      }
+      """
+
+        let migrator = TestMigrator()
+        let result = try migrator.migrate(source: input)
+
+        assertInlineSnapshot(of: result, as: .lines) {
+            """
+      import Testing
+
+      struct MainActorAvailabilityTests {
+        @available(*, deprecated)
+        @MainActor
+        @Test
+        func onMainActor() {
+          #expect(true == true)
+        }
+      }
+      """
+        }
+    }
+
+    @Test
+    func mainActorRemovalWithOtherAttributes() throws {
+        let input = """
+      import XCTest
+
+      final class MainActorAvailabilityTests: XCTestCase {
+        @available(*, deprecated)
+        @MainActor func testOnMainActor() {
+          XCTAssertTrue(true)
+        }
+      }
+      """
+
+        let migrator = TestMigrator(removeMainActor: true)
+        let result = try migrator.migrate(source: input)
+
+        assertInlineSnapshot(of: result, as: .lines) {
+            """
+      import Testing
+
+      struct MainActorAvailabilityTests {
+        @available(*, deprecated)
+        @Test
+        func onMainActor() {
+          #expect(true == true)
+        }
+      }
+      """
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `@MainActor` and other existing attributes are written on separate lines when adding `@Test`
- add `--remove-main-actor` flag to strip `@MainActor` annotations when desired
- cover `@MainActor` preservation and optional removal with regression tests
- document flag usage and clean up unused rewriter helper

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_689a58f35740832c80cc6c91f352c5eb