### PR TITLE
Preserve blank lines between migrated tests in extensions

### DIFF
--- a/Tests/SwiftTestingMigratorKitTests/IndentationTests.swift
+++ b/Tests/SwiftTestingMigratorKitTests/IndentationTests.swift
@@ -73,4 +73,46 @@ struct IndentationTests {
       """
         }
     }
+
+    @Test
+    func preservesEmptyLineBetweenExtensionTests() throws {
+        let input = """
+      import XCTest
+
+      final class ExtensionTests: XCTestCase {}
+
+      extension ExtensionTests {
+        func test_one() {
+          XCTAssertTrue(true)
+        }
+        func test_two() {
+          XCTAssertTrue(true)
+        }
+      }
+      """
+
+        let migrator = TestMigrator()
+        let result = try migrator.migrate(source: input)
+
+        assertInlineSnapshot(of: result, as: .lines) {
+            """
+      import Testing
+
+      struct ExtensionTests {
+      }
+
+      extension ExtensionTests {
+        @Test
+        func one() {
+          #expect(true == true)
+        }
+
+        @Test
+        func two() {
+          #expect(true == true)
+        }
+      }
+      """
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- ensure extension members are analyzed so migrated tests keep a blank line between functions
- add regression test for extension-based test methods

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b18ffa921c832cb38b5ba24baa3bbd