### PR TITLE
Preserve formatting for empty closures

### DIFF
--- a/Sources/SwiftTestingMigratorKit/XCTestToSwiftTestingRewriter.swift
+++ b/Sources/SwiftTestingMigratorKit/XCTestToSwiftTestingRewriter.swift
@@ -162,6 +162,13 @@ final class XCTestToSwiftTestingRewriter: SyntaxRewriter {
         return super.visit(node)
     }
 
+    override func visit(_ node: ClosureExprSyntax) -> ExprSyntax {
+        if node.statements.isEmpty {
+            return ExprSyntax(node)
+        }
+        return super.visit(node)
+    }
+
     // MARK: - Private Methods
 
     private func removeXCTestCaseInheritance(_ inheritanceClause: InheritanceClauseSyntax) -> InheritanceClauseSyntax? {


### PR DESCRIPTION
## Summary
- Avoid rewriting empty closure bodies during migration to maintain original single-line formatting

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a864d81c832c91a4d83de59166e2