### PR TITLE
Fix spacing for optional subscript migration

### DIFF
--- a/Tests/SwiftTestingMigratorKitTests/AssertionConversionTests.swift
+++ b/Tests/SwiftTestingMigratorKitTests/AssertionConversionTests.swift
@@ -184,6 +184,35 @@ struct AssertionConversionTests {
     }
 
     @Test
+    func optionalChainedSubscriptConversion() throws {
+        let input = """
+      import XCTest
+
+      final class DictionaryTests: XCTestCase {
+        func testOptionalSubscript() {
+          XCTAssertEqual(dictionary?["someKey"], "someValue")
+        }
+      }
+      """
+
+        let migrator = TestMigrator()
+        let result = try migrator.migrate(source: input)
+
+        assertInlineSnapshot(of: result, as: .lines) {
+            """
+      import Testing
+
+      struct DictionaryTests {
+        @Test
+        func optionalSubscript() {
+          #expect(dictionary?["someKey"] == "someValue")
+        }
+      }
+      """
+        }
+    }
+
+    @Test
     func complexBooleanExpressions() throws {
         let input = """
       import XCTest


### PR DESCRIPTION
## Summary
- remove space after optional chaining before subscripts during migration
- use generic dictionary key/value in optional subscript test

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b218a8b630832caae73de3f50182b0