### PR TITLE
feat: add force option to migrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ code stays familiar and easy to review.
 - **Comprehensive assertion mapping** – covers the most common XCTest assertions
 - **Early failure for unsupported expectations** – files using `expectation` or
   `waitForExpectations` produce a clear error message rather than an incorrect migration
+  (can be overridden with `--force`)
 
 ## Installation
 
@@ -42,6 +43,9 @@ SwiftTestingMigrator --file MyTests.swift --backup
 
 # Verbose output
 SwiftTestingMigrator --file MyTests.swift --verbose
+
+# Force migration even if unsupported patterns are found
+SwiftTestingMigrator --file MyTests.swift --force
 ```
 
 ## Examples
@@ -122,8 +126,8 @@ final class NetworkTests {
 
 ## Limitations
 
-- XCTest `expectation`/`waitForExpectations` APIs are not yet supported. The tool
-  will exit with an error when they are detected.
+- XCTest `expectation`/`waitForExpectations` APIs are not yet fully supported. The tool
+  will exit with an error when they are detected unless `--force` is used.
 - UI automation tests (`XCUIApplication`)
 - Performance tests (`XCTMetric`)
 - Objective-C test code

--- a/Sources/SwiftTestingMigrator/SwiftTestingMigrator.swift
+++ b/Sources/SwiftTestingMigrator/SwiftTestingMigrator.swift
@@ -54,11 +54,17 @@ struct SwiftTestingMigrator: AsyncParsableCommand {
     )
     var verbose = false
 
+    @Flag(
+        name: .long,
+        help: "Force migration even if unsupported patterns are detected"
+    )
+    var force = false
+
     func run() async throws {
         let migrator = TestMigrator()
 
         if let folder {
-            try processFolder(at: folder, using: migrator)
+            try processFolder(at: folder, using: migrator, force: force)
             return
         }
 
@@ -82,7 +88,7 @@ struct SwiftTestingMigrator: AsyncParsableCommand {
         }
 
         do {
-            let migratedContent = try migrator.migrate(source: originalContent)
+            let migratedContent = try migrator.migrate(source: originalContent, force: force)
 
             if dryRun {
                 print("🔍 Dry run - would make the following changes:")
@@ -123,7 +129,7 @@ struct SwiftTestingMigrator: AsyncParsableCommand {
         }
     }
 
-    private func processFolder(at path: String, using migrator: TestMigrator) throws {
+    private func processFolder(at path: String, using migrator: TestMigrator, force: Bool) throws {
         guard FileManager.default.fileExists(atPath: path) else {
             throw ValidationError("Folder not found: \(path)")
         }
@@ -144,7 +150,7 @@ struct SwiftTestingMigrator: AsyncParsableCommand {
 
             let original = try String(contentsOf: fileURL)
             do {
-                let migrated = try migrator.migrate(source: original)
+                let migrated = try migrator.migrate(source: original, force: force)
                 if migrated == original {
                     already.append(fileURL.path)
                     if verbose {

--- a/Sources/SwiftTestingMigratorKit/TestMigrator.swift
+++ b/Sources/SwiftTestingMigratorKit/TestMigrator.swift
@@ -13,7 +13,7 @@ public final class TestMigrator: Sendable {
     /// - Parameter source: The original Swift source code
     /// - Returns: Migrated Swift source code
     /// - Throws: MigrationError if migration fails
-    public func migrate(source: String) throws -> String {
+    public func migrate(source: String, force: Bool = false) throws -> String {
         // Parse the source code into AST
         let sourceFile = Parser.parse(source: source)
 
@@ -24,7 +24,7 @@ public final class TestMigrator: Sendable {
         }
 
         // Fail fast on unsupported expectation patterns
-        if containsExpectationUsage(sourceFile) {
+        if containsExpectationUsage(sourceFile) && !force {
             throw MigrationError.unsupportedPattern(
                 "XCTest expectations (expectation/waitForExpectations) are not supported"
             )

--- a/Tests/SwiftTestingMigratorKitTests/ErrorHandlingTests.swift
+++ b/Tests/SwiftTestingMigratorKitTests/ErrorHandlingTests.swift
@@ -205,4 +205,35 @@ struct ErrorHandlingTests {
             }
         }
     }
+
+    @Test
+    func forceAllowsExpectations() throws {
+        let input = """
+      import XCTest
+
+      final class ExpectationTests: XCTestCase {
+        func test_waits() {
+          let exp = expectation(description: "async work")
+          waitForExpectations(timeout: 1.0)
+        }
+      }
+      """
+
+        let migrator = TestMigrator()
+        let result = try migrator.migrate(source: input, force: true)
+
+        assertInlineSnapshot(of: result, as: .lines) {
+            """
+      import Testing
+
+      struct ExpectationTests {
+        @Test
+        func waits() async {
+          let exp = expectation(description: "async work")
+          waitForExpectations(timeout: 1.0)
+        }
+      }
+      """
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- allow migrations to continue despite unsupported patterns using new `--force` flag
- document `--force` usage and limitations
- cover forced migration of expectation-based tests

## Testing
- `swift test`
- `./scripts/lint.sh` *(fails: /usr/local/bin/swiftlint: cannot execute binary file)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ca3ab230832c969d3cabab701e97