### PR TITLE
Add XCTAssertThrowsError migration support

### DIFF
--- a/Tests/SwiftTestingMigratorKitTests/AssertionConversionTests.swift
+++ b/Tests/SwiftTestingMigratorKitTests/AssertionConversionTests.swift
@@ -184,6 +184,39 @@ struct AssertionConversionTests {
     }
 
     @Test
+    func assertThrowsErrorConversion() throws {
+        let input = """
+      import XCTest
+
+      final class ThrowingTests: XCTestCase {
+        func testThrowing() {
+          let sut = SUT()
+          XCTAssertThrowsError(try sut.performDangerousOperation())
+        }
+      }
+      """
+
+        let migrator = TestMigrator()
+        let result = try migrator.migrate(source: input)
+
+        assertInlineSnapshot(of: result, as: .lines) {
+            """
+      import Testing
+
+      struct ThrowingTests {
+        @Test
+        func throwing() {
+          let sut = SUT()
+          #expect(throws: (any Error).self) {
+            try sut.performDangerousOperation()
+          }
+        }
+      }
+      """
+        }
+    }
+
+    @Test
     func optionalChainedSubscriptConversion() throws {
         let input = """
       import XCTest

--- a/Tests/SwiftTestingMigratorKitTests/XCTestAssertionConverterTests.swift
+++ b/Tests/SwiftTestingMigratorKitTests/XCTestAssertionConverterTests.swift
@@ -178,6 +178,23 @@ struct XCTestAssertionConverterTests {
     }
 
     @Test
+    func convertXCTAssertThrowsError() throws {
+        let functionCall = createFunctionCall(
+            name: "XCTAssertThrowsError",
+            arguments: ["try sut.performDangerousOperation()"]
+        )
+
+        let result = XCTestAssertionConverter.convertXCTestAssertion(functionCall, functionName: "XCTAssertThrowsError")
+        let output = result?.description ?? ""
+
+        assertInlineSnapshot(of: output, as: .lines) {
+            """
+      #expect(throws: (any Error).self) { try sut.performDangerousOperation() }
+      """
+        }
+    }
+
+    @Test
     func convertUnknownAssertion() throws {
         let functionCall = createFunctionCall(
             name: "XCTAssertSomething",


### PR DESCRIPTION
## Summary
- migrate `XCTAssertThrowsError` into `#expect(throws:)` with a closure
- cover `XCTAssertThrowsError` in converter and full migration tests using a generic throwing operation
- output `(any Error).self` for the `throws` expectation
- ensure space before the closing brace in the converted `#expect` closure

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_e_68b6e6819b0c832c88f5a7b86678c965