### PR TITLE
Use isEmpty for empty string comparisons in XCTest assertions

### DIFF
--- a/Tests/SwiftTestingMigratorKitTests/AssertionConversionTests.swift
+++ b/Tests/SwiftTestingMigratorKitTests/AssertionConversionTests.swift
@@ -97,6 +97,39 @@ struct AssertionConversionTests {
     }
 
     @Test
+    func assertEmptyStringComparisons() throws {
+        let input = """
+      import XCTest
+
+      final class StringTests: XCTestCase {
+        func testEmpty() {
+          XCTAssertEqual(text, "")
+          XCTAssertTrue(text == "")
+          XCTAssertFalse(text == "")
+        }
+      }
+      """
+
+        let migrator = TestMigrator()
+        let result = try migrator.migrate(source: input)
+
+        assertInlineSnapshot(of: result, as: .lines) {
+            """
+      import Testing
+
+      struct StringTests {
+        @Test
+        func empty() {
+          #expect(text.isEmpty == true)
+          #expect(text.isEmpty == true)
+          #expect(text.isEmpty == false)
+        }
+      }
+      """
+        }
+    }
+
+    @Test
     func assertNilConversion() throws {
         let input = """
       import XCTest


### PR DESCRIPTION
## Summary
- convert `XCTAssertEqual` with empty string to use `isEmpty == true`
- rewrite boolean string-empty comparisons to use `.isEmpty`
- test migrating empty string comparisons in assertions

## Testing
- `swift test -q`


------
https://chatgpt.com/codex/tasks/task_e_68b816f54aa8832c9ae6592f082445bf